### PR TITLE
Fix error when activation has no traits

### DIFF
--- a/scripts/helpers/generate-activation.js
+++ b/scripts/helpers/generate-activation.js
@@ -44,7 +44,7 @@ export function generateActivations(item) {
                 );
             if (isRemaster) {
                 action.name = `${TEXT.ACTIVATION_TEXT}: ${descAction.split("</strong>")[0].replace("—", "")}`;
-                action.system.traits.value = descAction
+                action.system.traits.value = (descAction + "()")
                     .match(/\(([^)]+)\)/g)[0]
                     .slice(1, -1)
                     .split(",")


### PR DESCRIPTION
Fixes an error that happens when an activation has no traits, and therefore no parentheses. The first pair is matched, so adding an extra set at the end makes no difference if they already exist.